### PR TITLE
Make all test_config imports relative

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,4 +1,0 @@
-#/bin/bash
-rm -rf /srv/thirdparty/edgestore-stage/go/bin/
-rm -rf /srv/thirdparty/edgestore-stage/go/pkg/linux_amd64/code.google.com/p/gogoprotobuf
-

--- a/gogoproto/Makefile
+++ b/gogoproto/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../test_config/config
 
 regenerate:
 	protoc --dgo_out=. --proto_path=$(PROTO_PATH) *.proto

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. thetest.proto)

--- a/test/enumprefix/Makefile
+++ b/test/enumprefix/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. enumprefix.proto)

--- a/test/enumstringer/Makefile
+++ b/test/enumstringer/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. enumstringer.proto)

--- a/test/example/Makefile
+++ b/test/example/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. example.proto)

--- a/test/group/Makefile
+++ b/test/group/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. group.proto)

--- a/test/issue8/Makefile
+++ b/test/issue8/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. proto.proto)

--- a/test/moredefaults/Makefile
+++ b/test/moredefaults/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. md.proto)

--- a/test/packed/Makefile
+++ b/test/packed/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. packed.proto)

--- a/test/tags/Makefile
+++ b/test/tags/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. tags.proto)

--- a/test/unmarshalmerge/Makefile
+++ b/test/unmarshalmerge/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. unmarshalmerge.proto)

--- a/test/unrecognized/Makefile
+++ b/test/unrecognized/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. unrecognized.proto)

--- a/test/unrecognizedgroup/Makefile
+++ b/test/unrecognizedgroup/Makefile
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include /srv/github/src/github.com/dropbox/goprotoc/test_config/config
+include ../../test_config/config
 
 regenerate:
 	(protoc --proto_path=$(PROTO_PATH) --dgo_out=. unrecognizedgroup.proto)


### PR DESCRIPTION
Patrick, what shall we do with the test_config files? The env var and the go config have a absolute paths.
